### PR TITLE
Onedrive login selectors

### DIFF
--- a/keep-onedrive-active.py
+++ b/keep-onedrive-active.py
@@ -28,7 +28,7 @@ cred_dict = json.loads(os.getenv("ONEDRIVE"))
 
 onedrive = "https://onedrive.live.com"
 onedrive_signin = "https://onedrive.live.com/login/"
-onedrive_usr_sel = "//input[@type='email]"
+onedrive_usr_sel = "//input[@type='email']"
 onedrive_pwd_sel = "//input[@type='password']"
 onedrive_homepage = "https://onedrive.live.com/?id=root"
 iframe_sel = "//iframe[@class='signInFrame']"

--- a/keep-onedrive-active.py
+++ b/keep-onedrive-active.py
@@ -31,7 +31,7 @@ onedrive_signin = "https://onedrive.live.com/login/"
 onedrive_usr_sel = "//input[@type='email]"
 onedrive_pwd_sel = "//input[@type='password']"
 onedrive_homepage = "https://onedrive.live.com/?id=root"
-iframe_sel = "iframe.signInFrame"
+iframe_sel = "//iframe[@class='signInFrame']"
 
 
 def mkfilename(a):

--- a/keep-onedrive-active.py
+++ b/keep-onedrive-active.py
@@ -28,8 +28,8 @@ cred_dict = json.loads(os.getenv("ONEDRIVE"))
 
 onedrive = "https://onedrive.live.com"
 onedrive_signin = "https://onedrive.live.com/login/"
-onedrive_usr_sel = "input.form-control"
-onedrive_pwd_sel = "input.form-control"
+onedrive_usr_sel = "//input[@type='email]"
+onedrive_pwd_sel = "//input[@type='password']"
 onedrive_homepage = "https://onedrive.live.com/?id=root"
 iframe_sel = "iframe.signInFrame"
 


### PR DESCRIPTION
Updated login selectors to use the **type** attribute

GitHub Action log extract indicates successful log in:

```
Run python keep-onedrive-active.py
2024-04-15	11:05:08:742073	INFO	Launching browser
2024-04-15	11:05:10:196644	INFO	Retrieving login page 'https://onedrive.live.com/login/'
2024-04-15	11:05:15:036745	INFO	Logging in
2024-04-15	11:05:18:4894[12](https://github.com/schmwong/keep-accounts-active/actions/runs/8687997111/job/23822687846#step:6:13)	INFO	Logged in successfully
Traceback (most recent call last):
  File "/home/runner/work/keep-accounts-active/keep-accounts-active/keep-onedrive-active.py", line 126, in <module>
    onedrive_login(instance)
  File "/home/runner/work/keep-accounts-active/keep-accounts-active/keep-onedrive-active.py", line 101, in onedrive_login
    instance.redirect(href_sel="a[class*='od-QuotaBar']")
  File "/home/runner/work/keep-accounts-active/keep-accounts-active/login_logger.py", line 150, in redirect
    ).get_attribute("href")
  File "/home/runner/.local/lib/python3.10/site-packages/playwright/sync_api/_generated.py", line 16143, in get_attribute
    self._sync(self._impl_obj.get_attribute(name=name, timeout=timeout))
  File "/home/runner/.local/lib/python3.10/site-packages/playwright/_impl/_sync_base.py", line 115, in _sync
    return task.result()
  File "/home/runner/.local/lib/python3.10/site-packages/playwright/_impl/_locator.py", line 409, in get_attribute
    return await self._frame.get_attribute(
  File "/home/runner/.local/lib/python3.10/site-packages/playwright/_impl/_frame.py", line 628, in get_attribute
    return await self._channel.send("getAttribute", locals_to_params(locals()))
  File "/home/runner/.local/lib/python3.10/site-packages/playwright/_impl/_connection.py", line 59, in send
    return await self._connection.wrap_api_call(
  File "/home/runner/.local/lib/python3.10/site-packages/playwright/_impl/_connection.py", line 5[13](https://github.com/schmwong/keep-accounts-active/actions/runs/8687997111/job/23822687846#step:6:14), in wrap_api_call
    raise rewrite_error(error, f"{parsed_st['apiName']}: {error}") from None
playwright._impl._errors.TimeoutError: Locator.get_attribute: Timeout 30000ms exceeded.
Call log:
waiting for locator("a[class*='od-QuotaBar']")

Error: Process completed with exit code 1.
```