### PR TITLE
Mega: `redirect` method "button_sel" kwarg added

### DIFF
--- a/keep-mega-active.py
+++ b/keep-mega-active.py
@@ -82,7 +82,7 @@ def mega_login(instance):
     with sync_playwright() as pw:
         logger = instance.logger
         instance.one_step_login(pw, "#login_form > button")
-        instance.redirect(href_sel="a.dashboard-link")
+        instance.redirect(button_sel="div[name*=dashboard][aria-role=button]")
         query_mega_storage(instance)
         logger.info("Tasks complete. Closing browser")
 

--- a/login_logger.py
+++ b/login_logger.py
@@ -144,6 +144,11 @@ class LoginLogger:
     def redirect(self, **kwargs):
         logger = self.logger
         page = self.tab
+        if "button_sel" in kwargs:
+            page.locator(kwargs.get("button_sel")).click()
+            page.wait_for_load_state("domcontentloaded")
+            self.dashboard_url = page.url
+            return 0
         if "href_sel" in kwargs:
             self.dashboard_url = self.url + page.locator(
                 kwargs.get("href_sel")


### PR DESCRIPTION
## Issue
Mega had a minor update in which the anchor link to the dashboard (`a.dashboard-link`) got replaced by a button (`div[name=dashboard][aria-role=button]`).

## Fix
In the module `login_logger.py`, this PR adds to the `redirect` method an option to click if a button selector is used in the keyword argument instead of the previously used href selector.

---

GitHub Actions log output before fix:

```
2024-04-19	06:46:17:780199	INFO	Launching browser
2024-04-19	06:46:19:722025	INFO	Retrieving login page 'https://mega.nz/login'
2024-04-19	06:46:22:466234	INFO	Logging in
2024-04-19	06:46:26:999902	INFO	Logged in successfully
Traceback (most recent call last):
  File "/home/runner/work/keep-accounts-active/keep-accounts-active/keep-mega-active.py", line 110, in <module>
    mega_login(instance)
  File "/home/runner/work/keep-accounts-active/keep-accounts-active/keep-mega-active.py", line 85, in mega_login
    instance.redirect(href_sel="a.dashboard-link")
  File "/home/runner/work/keep-accounts-active/keep-accounts-active/login_logger.py", line 150, in redirect
    ).get_attribute("href")
  File "/home/runner/.local/lib/python3.10/site-packages/playwright/sync_api/_generated.py", line 16143, in get_attribute
    self._sync(self._impl_obj.get_attribute(name=name, timeout=timeout))
  File "/home/runner/.local/lib/python3.10/site-packages/playwright/_impl/_sync_base.py", line 115, in _sync
    return task.result()
  File "/home/runner/.local/lib/python3.10/site-packages/playwright/_impl/_locator.py", line 409, in get_attribute
    return await self._frame.get_attribute(
  File "/home/runner/.local/lib/python3.10/site-packages/playwright/_impl/_frame.py", line 628, in get_attribute
    return await self._channel.send("getAttribute", locals_to_params(locals()))
  File "/home/runner/.local/lib/python3.10/site-packages/playwright/_impl/_connection.py", line 59, in send
    return await self._connection.wrap_api_call(
  File "/home/runner/.local/lib/python3.10/site-packages/playwright/_impl/_connection.py", line 5[13](https://github.com/schmwong/keep-accounts-active/actions/runs/8749543593/job/24011405441#step:6:14), in wrap_api_call
    raise rewrite_error(error, f"{parsed_st['apiName']}: {error}") from None
playwright._impl._errors.TimeoutError: Locator.get_attribute: Timeout 30000ms exceeded.
Call log:
waiting for locator("a.dashboard-link")
```

---

GitHub Actions log output after fix:

```
2024-04-19	16:16:56:989620	INFO	Launching browser
2024-04-19	16:17:00:454167	INFO	Retrieving login page 'https://mega.nz/login'
2024-04-19	16:17:04:317800	INFO	Logging in
2024-04-19	16:17:08:563317	INFO	Logged in successfully
2024-04-19	16:17:10:129413	INFO	Getting storage details from 'https://mega.nz/fm/dashboard'
2024-04-19	16:17:10:129647	DEBUG	Profile name: p w
2024-04-19	16:17:10:129730	DEBUG	Email: ***
2024-04-19	16:17:10:129800	DEBUG	Plan: Free
2024-04-19	16:17:10:172876	DEBUG	Cloud drive: (15.68 GB)
2024-04-19	16:17:10:199614	DEBUG	Backups:  0 MB
2024-04-19	16:17:10:218342	DEBUG	Versions: (0 B)
2024-04-19	16:17:10:233826	DEBUG	Rubbish bin: (0 B)
2024-04-19	16:17:10:252806	DEBUG	Available: (34.32 GB)
2024-04-19	16:17:10:252871	INFO	Tasks complete. Closing browser
2024-04-19	16:17:10:979562	INFO	Launching browser
2024-04-19	16:17:13:044524	INFO	Retrieving login page 'https://mega.nz/login'
2024-04-19	16:17:16:129997	INFO	Logging in
2024-04-19	16:17:21:160412	INFO	Logged in successfully
2024-04-19	16:17:22:831190	INFO	Getting storage details from 'https://mega.nz/fm/dashboard'
2024-04-19	16:17:22:831361	DEBUG	Profile name: s w
2024-04-19	16:17:22:831441	DEBUG	Email: ***
2024-04-19	16:17:22:831496	DEBUG	Plan: Free
2024-04-19	16:17:22:881597	DEBUG	Cloud drive: (7.30 GB)
2024-04-19	16:17:22:903373	DEBUG	Backups:  0 MB
2024-04-19	16:17:22:918438	DEBUG	Versions: (0 B)
2024-04-19	16:17:22:933787	DEBUG	Rubbish bin: (0 B)
2024-04-19	16:17:22:949115	DEBUG	Available: (42.70 GB)
2024-04-19	16:17:22:949335	INFO	Tasks complete. Closing browser
```