### PR TITLE
Onedrive: bypass "verify your email" page

### DIFF
--- a/keep-onedrive-active.py
+++ b/keep-onedrive-active.py
@@ -28,7 +28,7 @@ cred_dict = json.loads(os.getenv("ONEDRIVE"))
 
 onedrive = "https://onedrive.live.com"
 onedrive_signin = "https://onedrive.live.com/login/"
-onedrive_usr_sel = "//input[@type='email]"
+onedrive_usr_sel = "//input[@type='email']"
 onedrive_pwd_sel = "//input[@type='password']"
 onedrive_homepage = "https://onedrive.live.com/?id=root"
 iframe_sel = "//iframe[@class='signInFrame']"

--- a/keep-onedrive-active.py
+++ b/keep-onedrive-active.py
@@ -31,7 +31,7 @@ onedrive_signin = "https://onedrive.live.com/login/"
 onedrive_usr_sel = "//input[@type='email]"
 onedrive_pwd_sel = "//input[@type='password']"
 onedrive_homepage = "https://onedrive.live.com/?id=root"
-iframe_sel = "iframe.signInFrame"
+iframe_sel = "//iframe[@class='signInFrame']"
 
 
 def mkfilename(a):

--- a/keep-onedrive-active.py
+++ b/keep-onedrive-active.py
@@ -98,7 +98,7 @@ def onedrive_login(instance):
         # Browser session to generate new csv log file
         logger = instance.logger
         instance.iframe_login(pw, iframe_sel)
-        instance.redirect(href_sel="a[class*='od-QuotaBar']")
+        instance.redirect(href_sel="//a[contains(@class, 'usedQuotaText')]")
         query_onedrive_storage(instance)
         logger.info("Tasks complete. Closing browser")
 

--- a/keep-onedrive-active.py
+++ b/keep-onedrive-active.py
@@ -28,8 +28,8 @@ cred_dict = json.loads(os.getenv("ONEDRIVE"))
 
 onedrive = "https://onedrive.live.com"
 onedrive_signin = "https://onedrive.live.com/login/"
-onedrive_usr_sel = "input.form-control"
-onedrive_pwd_sel = "input.form-control"
+onedrive_usr_sel = "//input[@type='email]"
+onedrive_pwd_sel = "//input[@type='password']"
 onedrive_homepage = "https://onedrive.live.com/?id=root"
 iframe_sel = "iframe.signInFrame"
 

--- a/keep-onedrive-active.py
+++ b/keep-onedrive-active.py
@@ -102,7 +102,7 @@ def onedrive_login(instance):
         query_onedrive_storage(instance)
         logger.info("Tasks complete. Closing browser")
 
-    # Remove FileHandlder to prevent reopening the previous instance's file in the next instance
+    # Remove FileHandler to prevent reopening the previous instance's file in the next instance
     # due to the Class Variable getting recreated during "self.logger.addHandler(self.DuoHandler)"
     logger.removeHandler(instance.DuoHandler)
 

--- a/login_logger.py
+++ b/login_logger.py
@@ -132,6 +132,12 @@ class LoginLogger:
         frame = page.frame_locator(frame_locator).locator(self.usr_sel)
         frame.fill(self.usr)
         page.keyboard.press("Enter")
+        page.wait_for_timeout(2529)
+        # --- Email confirmation bypass --- #
+        if (page.locator("div#proofConfirmationTitle").count() > 0
+                and page.locator("div#proofConfirmationTitle").inner_text().lower() == "verify your email"):
+            page.get_by_role("button").get_by_text("Use your password instead").click()
+        # --------------------------------- #
         page.fill(self.pwd_sel, self.pwd)
         page.keyboard.press("Enter")
         page.wait_for_timeout(2529)


### PR DESCRIPTION
Remote logging in to Onedrive may navigate to this page.

![Screenshot_2024-12-14_16-41-52](https://github.com/user-attachments/assets/1d79f396-70b4-4687-bb64-4727ea1d9541)

A short script has been added to select the "use your password" option and proceed to the password input page to continue logging in.

```
if (page.locator("div#proofConfirmationTitle").count() > 0
        and page.locator("div#proofConfirmationTitle").inner_text().lower() == "verify your email"):
    page.get_by_role("button").get_by_text("Use your password instead").click()
```