### PR TITLE
Onedrive: email bypass and stay signed-in element selectors

### DIFF
--- a/keep-onedrive-active.py
+++ b/keep-onedrive-active.py
@@ -28,7 +28,7 @@ cred_dict = json.loads(os.getenv("ONEDRIVE"))
 
 onedrive = "https://onedrive.live.com"
 onedrive_signin = "https://onedrive.live.com/login/"
-onedrive_usr_sel = "//input[@type='email]"
+onedrive_usr_sel = "//input[@type='email']"
 onedrive_pwd_sel = "//input[@type='password']"
 onedrive_homepage = "https://onedrive.live.com/?id=root"
 iframe_sel = "//iframe[@class='signInFrame']"

--- a/keep-onedrive-active.py
+++ b/keep-onedrive-active.py
@@ -31,7 +31,7 @@ onedrive_signin = "https://onedrive.live.com/login/"
 onedrive_usr_sel = "//input[@type='email]"
 onedrive_pwd_sel = "//input[@type='password']"
 onedrive_homepage = "https://onedrive.live.com/?id=root"
-iframe_sel = "iframe.signInFrame"
+iframe_sel = "//iframe[@class='signInFrame']"
 
 
 def mkfilename(a):

--- a/keep-onedrive-active.py
+++ b/keep-onedrive-active.py
@@ -98,7 +98,7 @@ def onedrive_login(instance):
         # Browser session to generate new csv log file
         logger = instance.logger
         instance.iframe_login(pw, iframe_sel)
-        instance.redirect(href_sel="a[class*='od-QuotaBar']")
+        instance.redirect(href_sel="//a[contains(@class, 'usedQuotaText')]")
         query_onedrive_storage(instance)
         logger.info("Tasks complete. Closing browser")
 

--- a/keep-onedrive-active.py
+++ b/keep-onedrive-active.py
@@ -28,8 +28,8 @@ cred_dict = json.loads(os.getenv("ONEDRIVE"))
 
 onedrive = "https://onedrive.live.com"
 onedrive_signin = "https://onedrive.live.com/login/"
-onedrive_usr_sel = "input.form-control"
-onedrive_pwd_sel = "input.form-control"
+onedrive_usr_sel = "//input[@type='email]"
+onedrive_pwd_sel = "//input[@type='password']"
 onedrive_homepage = "https://onedrive.live.com/?id=root"
 iframe_sel = "iframe.signInFrame"
 

--- a/keep-onedrive-active.py
+++ b/keep-onedrive-active.py
@@ -102,7 +102,7 @@ def onedrive_login(instance):
         query_onedrive_storage(instance)
         logger.info("Tasks complete. Closing browser")
 
-    # Remove FileHandlder to prevent reopening the previous instance's file in the next instance
+    # Remove FileHandler to prevent reopening the previous instance's file in the next instance
     # due to the Class Variable getting recreated during "self.logger.addHandler(self.DuoHandler)"
     logger.removeHandler(instance.DuoHandler)
 

--- a/login_logger.py
+++ b/login_logger.py
@@ -134,14 +134,16 @@ class LoginLogger:
         page.keyboard.press("Enter")
         page.wait_for_timeout(2529)
         # --- Email confirmation bypass --- #
-        if (page.locator("div#proofConfirmationTitle").count() > 0
-                and page.locator("div#proofConfirmationTitle").inner_text().lower() == "verify your email"):
-            page.get_by_role("button").get_by_text("Use your password instead").click()
+        if (page.locator("input#proof-confirmation-email-input").count() > 0
+                and page.locator("h1[data-testid='title']").inner_text().lower() == "verify your email"):
+            page.get_by_role("button").get_by_text("Use your password").click()
         # --------------------------------- #
         page.fill(self.pwd_sel, self.pwd)
         page.keyboard.press("Enter")
         page.wait_for_timeout(2529)
-        page.keyboard.press("Enter")
+        page.locator('button[data-testid="primaryButton"]').click()
+        
+        # page.keyboard.press("Enter")
         logger.info("Logging in")
         page.wait_for_url(self.homepage + "**", wait_until="domcontentloaded")
         logger.info("Logged in successfully")

--- a/login_logger.py
+++ b/login_logger.py
@@ -132,6 +132,12 @@ class LoginLogger:
         frame = page.frame_locator(frame_locator).locator(self.usr_sel)
         frame.fill(self.usr)
         page.keyboard.press("Enter")
+        page.wait_for_timeout(2529)
+        # --- Email confirmation bypass --- #
+        if (page.locator("div#proofConfirmationTitle").count() > 0
+                and page.locator("div#proofConfirmationTitle").inner_text().lower() == "verify your email"):
+            page.get_by_role("button").get_by_text("Use your password instead").click()
+        # --------------------------------- #
         page.fill(self.pwd_sel, self.pwd)
         page.keyboard.press("Enter")
         page.wait_for_timeout(2529)


### PR DESCRIPTION
Similar issue to [PR#16](https://github.com/schmwong/keep-accounts-active/pull/16). The email confirmation page elements have changed:

![Screenshot_2025-05-08_14-23-03](https://github.com/user-attachments/assets/36a21b11-f75a-4612-8cbb-c2d6d5fcf736)

Code to bypass this confirmation and navigate back to the password input screen has been updated with the new element selectors:

```python
if (page.locator("input#proof-confirmation-email-input").count() > 0
                and page.locator("h1[data-testid='title']").inner_text().lower() == "verify your email"):
            page.get_by_role("button").get_by_text("Use your password").click()
```

---

The "Stay Signed-in" page has also been updated:

![Screenshot_2025-05-08_14-40-40](https://github.com/user-attachments/assets/3e8333a6-fc17-42e6-89c4-7831707c3fd6)

A "Learn More" button has been added before the "Yes" button, and is clicked on by default when pressing the `Enter` key.
The code has therefore been updated to manually select and click on the "Yes" button.

```python
page.locator('button[data-testid="primaryButton"]').click()
```

